### PR TITLE
Set BIG_CREATION in distribution flags

### DIFF
--- a/pyrlang/dist_proto/flags.py
+++ b/pyrlang/dist_proto/flags.py
@@ -58,6 +58,7 @@ DFLAG_MAP_TAG = 0x20000
 """ The node can handle map encoding. """
 
 DFLAG_BIG_CREATION = 0x40000
+""" The node can handle NEW_PID, NEW_PORT and NEWER_REFERENCE. """
 
 # Added in R21-R22
 DFLAG_SEND_SENDER = 0x80000
@@ -81,6 +82,7 @@ DEFAULT_DFLAGS = (DFLAG_EXT_REFS |
                   DFLAG_BIT_BINARIES |
                   DFLAG_NEW_FLOATS |
                   DFLAG_MAP_TAG |
+                  DFLAG_BIG_CREATION |
                   DFLAG_UTF8_ATOMS | DFLAG_SMALL_ATOM_TAGS |
                   DFLAG_DIST_MONITOR_NAME | DFLAG_DIST_MONITOR)
 """ Default flags value represents current Pyrlang library features


### PR DESCRIPTION
This allows interop with Erlang OTP/23 and addresses issue #67. It depends on https://github.com/Pyrlang/Term/pull/16