### PR TITLE
Update Distribution Protocol to work with OTP-25 nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ example10b:
 	elixir --name elixir@127.0.0.1 --cookie COOKIE \
 		examples/elixir/e10.exs
 
+# Run `make iexnode` to run Elixir shell prepared to play with above examples
+.PHONY: iexnode
+iexnode:
+	iex --name erl@127.0.0.1 --cookie COOKIE --dot-iex examples/iexnode.exs
+
 $(ROOT)/examples/%.beam: $(ROOT)/examples/%.erl
 	cd $(ROOT)/examples && erlc $<
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For those times when you absolutely need assistance and email is too slow, here'
 Features
 --------
 
-*   Erlang distribution protocol for Erlang versions 21, 22 and 23
+*   Erlang distribution protocol for Erlang versions 19 to 25
 *   Registry of Python 'processes', which have an Erlang-compatible process
     identifier and an optional registered name
 *   Send and receive messages locally and remotely by pid or name

--- a/examples/iexnode.exs
+++ b/examples/iexnode.exs
@@ -1,0 +1,38 @@
+# iex --dot-iex iexnode.exs
+
+erlnode = :"erl@127.0.0.1"
+if Node.alive?() do
+  ^erlnode = Node.self()
+else
+  {:ok, _pid} = :net_kernel.start([erlnode, :longnames])
+  Node.set_cookie(:COOKIE)
+end
+
+Process.register(self(), :shell)
+
+unless :code.is_loaded(PyTest) do
+  defmodule PyTest do
+    @pynode :"py@127.0.0.1"
+    @my_process {:my_process, @pynode}
+
+    IO.write("""
+      ***
+      *** Play with #{@pynode} node using #{inspect __MODULE__} module.
+      ***
+      """)
+
+    def net_adm_ping do
+      :net_adm.ping(@pynode)
+    end
+
+    def send_my_process(term \\ :hello) do
+      send(@my_process, term)
+    end
+
+    def call_my_process(term \\ "hello") do
+      GenServer.call(@my_process, term, 3000)
+    end
+  end
+end
+
+

--- a/pyrlang/dist_proto/base_dist_protocol.py
+++ b/pyrlang/dist_proto/base_dist_protocol.py
@@ -104,10 +104,11 @@ class BaseDistProtocol(asyncio.Protocol):
         self.inbox_ = asyncio.Queue()
         """ Inbox is used to ask the connection to do something. """
 
-        self.peer_distr_version_ = (None, None)  # type: (int, int)
-        """ Protocol version range supported by the remote peer. Erlang/OTP 
-            versions 19-20 supports protocol version 7, older Erlangs down to 
-            R6B support version 5. """
+        self.dist_vsn_ = None # type: int
+        """ Protocol version range supported by the remote peer and us.
+            Erlang/OTP since R6B supports protocol version 5.
+            In OTP-23 protocol version 6 was added as optional,
+            which became mandatory in OTP-25. """
 
         self.peer_flags_ = 0
         self.peer_name_ = None  # type: Union[None, str]

--- a/pyrlang/dist_proto/distribution.py
+++ b/pyrlang/dist_proto/distribution.py
@@ -108,15 +108,16 @@ class ErlangDistribution:
             :param remote_node: String with node 'name@ip'
             :return: boolean whether the connection succeeded
         """
-        host_port = await EPMDClient.query_node(remote_node)
-        if host_port is None:
+        host_port_version = await EPMDClient.query_node(remote_node)
+        if host_port_version is None:
             # Connection to node failed, node is not known
             return False
         else:
             await asyncio.get_event_loop().create_connection(
-                lambda: DistClientProtocol(node_name=local_node),
-                host=host_port[0],
-                port=host_port[1]
+                lambda: DistClientProtocol(node_name=local_node,
+                                           dist_vsn=host_port_version[2]),
+                host=host_port_version[0],
+                port=host_port_version[1]
             )
             return True
 

--- a/pyrlang/dist_proto/flags.py
+++ b/pyrlang/dist_proto/flags.py
@@ -75,6 +75,11 @@ DFLAG_EXIT_PAYLOAD = 0x400000
 DFLAG_FRAGMENTS = 0x800000
 """ The node supports fragmentation for large packets. """
 
+DFLAGS_HANDSHAKE_23 = 0x1000000
+""" The node supports the new connection setup handshake (version 6) introduced in OTP 23.
+    This flag is mandatory (from OTP 25). If not present, the connection is refused.
+"""
+
 DEFAULT_DFLAGS = (DFLAG_EXT_REFS |
                   DFLAG_EXT_PIDS_PORTS |
                   DFLAG_FUN_TAGS | DFLAG_NEW_FUN_TAGS |
@@ -84,7 +89,8 @@ DEFAULT_DFLAGS = (DFLAG_EXT_REFS |
                   DFLAG_MAP_TAG |
                   DFLAG_BIG_CREATION |
                   DFLAG_UTF8_ATOMS | DFLAG_SMALL_ATOM_TAGS |
-                  DFLAG_DIST_MONITOR_NAME | DFLAG_DIST_MONITOR)
+                  DFLAG_DIST_MONITOR_NAME | DFLAG_DIST_MONITOR |
+                  DFLAGS_HANDSHAKE_23)
 """ Default flags value represents current Pyrlang library features
     as a combination of feature bits.
 """

--- a/pyrlang/dist_proto/version.py
+++ b/pyrlang/dist_proto/version.py
@@ -16,26 +16,28 @@
     protocol
 """
 
-DIST_VSN = 5
-DIST_VSN_PAIR = (DIST_VSN, DIST_VSN)
+DIST_VSN_MAX = 6  # optional since OTP-23, made mandatory in OTP-25
+DIST_VSN_MIN = 5  # nodes older than OTP-23 down to ancient R6B
+
+DIST_VSN_PAIR = (DIST_VSN_MAX, DIST_VSN_MIN)
 " Supported dist_proto protocol version (MAX,MIN). "
 
 
 def dist_version_check(max_min: tuple) -> bool:
-    """ Check pair of versions against version which is supported by us
+    """ Check pair of versions against versions which are supported by us
 
         :type max_min: tuple(int, int)
         :param max_min: (Max, Min) version pair for peer-supported dist version
     """
-    return max_min[0] >= DIST_VSN >= max_min[1]
+    return DIST_VSN_MIN <= max_min[0] and max_min[1] <= DIST_VSN_MAX # do ranges overlap?
 
 
-def check_valid_dist_version(max_min: tuple) -> bool:
+def check_valid_dist_version(dist_vsn: int) -> bool:
     """
     Check that the version is supported
-    :param max_min: tuple(int, int
+    :param dist_vsn: int
     :return: True if ok
     """
-    return max_min[0] <= DIST_VSN <= max_min[1]
+    return DIST_VSN_MIN <= dist_vsn <= DIST_VSN_MAX
 
-# __all__ = ['DIST_VSN', 'DIST_VSN_PAIR']
+# __all__ = ['DIST_VSN_MAX', 'DIST_VSN_MIN', 'DIST_VSN_PAIR']


### PR DESCRIPTION
(fixes #84)

OTP-25, ERTS User's Guide
https://www.erlang.org/docs/25/apps/erts/erl_dist_protocol.html#distribution-handshake
13.2  Distribution Handshake
The protocol was introduced in Erlang/OTP R6 and amended in OTP 23.
From OTP 25 support for the older protocol was dropped.
Therefor an OTP 25 node can not connect to nodes older than OTP 23.

That's OTP, but in this commit attempt was made to support OTP-25
while preserving connectivity to older nodes than OTP-23.